### PR TITLE
chore: license to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2022, Remirror Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # prosemirror-migration
 
-_prosemirror-migration_ is a tool for migrating ProseMirror documents when you have breaking changes to your [document schema](https://prosemirror.net/docs/ref/#model.Document_Schema).
+_prosemirror-migration_ is a tool for migrating [ProseMirror][prosemirror] documents when you have breaking changes to your [document schema](https://prosemirror.net/docs/ref/#model.Document_Schema).
 
 It takes a **JSON encoded** ProseMirror document, and recursively descends through each node, executing a migration strategy for a node type.
 
@@ -105,7 +105,7 @@ As well as the `cite` attribute update, note the addition of a version attribute
 }
 ```
 
-So far, we have only migrated `blockquote` nodes, but it's likely you want to migrate other nodes too. 
+So far, we have only migrated `blockquote` nodes, but it's likely you want to migrate other nodes too.
 
 ### Migrating multiple node types
 
@@ -199,3 +199,14 @@ For instance if your manifest defines 5 versions, _prosemirror-migration_ skips 
 |          2          |     3, 4 and 5    |
 |          4          |         5         |
 |          5          | _&lt;nothing&gt;_ |
+
+## Contributing
+
+Please read our [contribution guide][contribution guide] for details on our code of conduct, and the process for submitting pull requests.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
+
+[contribution guide]: https://remirror.io/docs/contributing
+[prosemirror]: https://prosemirror.net

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc --noEmit false"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@remirror/core-types": "~1.0.1",
     "lodash": "^4.17.21"


### PR DESCRIPTION
It seems that remirror projects are generally MIT-licensed so here's a PR to make this repo consistent with that pattern.

(Also, it seems that ISC.org has deprecated their usage of the ISC license: https://www.isc.org/licenses/)